### PR TITLE
Fix a few typos

### DIFF
--- a/everything-you-need-to-know-about-json/article.md
+++ b/everything-you-need-to-know-about-json/article.md
@@ -165,7 +165,7 @@ If you ever need to serialise circular structures, there are libraries available
 
 ## An elegant solution
 
-[JSON](https://app.pluralsight.com/library/courses/json-csharp-jsondotnet-getting-started/table-of-contents) is an especially elegant solution to serialisation. It’s effectively language agnostic, yet it directly works with values that we actually have in a our programs. The JSON format is derived from JavaScript syntax, which is a lot like C syntax, so programmers generally find it easy to read and edit the serialised data directly, and we don’t have to reference schemas to do it.
+[JSON](https://app.pluralsight.com/library/courses/json-csharp-jsondotnet-getting-started/table-of-contents) is an especially elegant solution to serialisation. It’s effectively language agnostic, yet it directly works with values that we actually have in our programs. The JSON format is derived from JavaScript syntax, which is a lot like C syntax, so programmers generally find it easy to read and edit the serialised data directly, and we don’t have to reference schemas to do it.
 
 ### JSON everywhere
 

--- a/faq.md
+++ b/faq.md
@@ -57,7 +57,7 @@ Yes! That's why we've built the editing tools on this site. It's easy to share a
 One easy thing you can do is to check-out what else is out their for this particular subject. Try doing a quick search now for some topics that interest you. Other articles are generally OK so long as there is enough unique/useful content that sets your article apart. Are there ideas you can talk about in your proposed article that hasn't already been written? Enough interesting unique contributions that can be added that moves the world's knowledge forward? Those are some things to think about.
 
 ### What is the writing process?
-1. [Submit an tutorial](/write/)
+1. [Submit a tutorial](/write/)
 2. Share a link for suggestions to your article with friends, co-workers, etc.
 3. Continue improving your article with the community help
 4. Our editors will also assist you with improving your article

--- a/how-to-analyze-employee-data-using-sql/article.md
+++ b/how-to-analyze-employee-data-using-sql/article.md
@@ -1,6 +1,6 @@
 When it comes to how to analyze employee data, there are fewer more complex data structures to work with. Probably the biggest challenge with working with an employee data set is how unassuming it may seem to start. Let's take a typical employee table from a Human Resources Information System (HRIS) and see how we can run some common analytical queries against it.
 
-Here is a table structure for how our data is stored. This is typical of many HRIS sytems I've seen in my days so we'll stick with this as an example.
+Here is a table structure for how our data is stored. This is typical of many HRIS systems I've seen in my days so we'll stick with this as an example.
 
 ## Table Name: emps
 

--- a/how-to-create-a-calculator-application-with-ionic-framework-by-using-ionic-creator-for-ui/article.md
+++ b/how-to-create-a-calculator-application-with-ionic-framework-by-using-ionic-creator-for-ui/article.md
@@ -21,7 +21,7 @@ Since there are not so many Calculator applications in the App store (around **5
 
 ![](http://i.imgur.com/hW4ZTKW.jpg)
 
-All jokes and hopes aside, this seemed to be a decent "more serious", but still easy to acomplish, tutorial. Let's start this tutorial by creating the interface for our application.
+All jokes and hopes aside, this seemed to be a decent "more serious", but still easy to accomplish, tutorial. Let's start this tutorial by creating the interface for our application.
 
 ## Calculator interface mockup
 Before starting any application, we should know what we want (well, at least in general). We should know what problem are we trying to solve with our application and how are we going to solve it. Also, we would need to have a decent idea of how we would want our application to look like. 
@@ -82,7 +82,7 @@ Select the Input component (by clicking it in the PAGES panel in the upper left 
 
 Next, according to our mockup, we should add buttons that would represent the digits from **0** to **9**, and the buttons that would represent adding (**+**), substracting (**-**), multiplying (**x**) and dividing (**/**) operations. Also, we will need the equals button (**=**) and a clear button (**C**).
 
-In the first row we need to have 4 buttons, the ones representing digits 7, 8, 9 and one representing a dividing operation. To acomplish this, we will use a **Button Bar** component from the Components panel so that we'll drag&amp;drop it just below the Input field on the screen. You should see something like this now in your Ionic Creator window:
+In the first row we need to have 4 buttons, the ones representing digits 7, 8, 9 and one representing a dividing operation. To accomplish this, we will use a **Button Bar** component from the Components panel so that we'll drag&amp;drop it just below the Input field on the screen. You should see something like this now in your Ionic Creator window:
 
 ![](http://i.imgur.com/CVcreWF.jpg)
 
@@ -190,7 +190,7 @@ We should see something similar to the image below:
 
 ![](http://i.imgur.com/Kp49zVS.png)
 
-Btw, the ruller and the Device setting (Apple iPhone 6) are a part of an awesome Developer tools in Chrome browser, which I highly recommend.
+Btw, the ruler and the Device setting (Apple iPhone 6) are a part of an awesome Developer tools in Chrome browser, which I highly recommend.
 
 > If you get an error similar to this:
 > `Unable to locate the ionic.project file. Are you in your project directory? (CLI v1.6.4)`
@@ -248,7 +248,7 @@ The contents of the `.bowerrc` file is shown below:
 ```
 
 ### config.xml file
-**config.xml** is a configuration file for the [Cordova](https://cordova.apache.org/) project (as you may remeber from the [first post](http://blog.pluralsight.com/ionic-framework-on-mac-and-windows), Ionic is built on top of Cordova). It contains some meta information about the app like permissions and a list of Cordova plugins which are used in the app. To learn more about available settings in the `config.xml` file, please refer to the [official documentation](https://cordova.apache.org/docs/en/4.0.0/config_ref_index.md.html).
+**config.xml** is a configuration file for the [Cordova](https://cordova.apache.org/) project (as you may remember from the [first post](http://blog.pluralsight.com/ionic-framework-on-mac-and-windows), Ionic is built on top of Cordova). It contains some meta information about the app like permissions and a list of Cordova plugins which are used in the app. To learn more about available settings in the `config.xml` file, please refer to the [official documentation](https://cordova.apache.org/docs/en/4.0.0/config_ref_index.md.html).
 
 ### gulpfile.js file
 **gulpfile.js** is a configuration file for [Gulp](http://gulpjs.com/).
@@ -265,7 +265,7 @@ Another popular task runner is [Grunt](http://gruntjs.com/). However, from my pe
 ### package.json
 **package.json** is a file used by `npm` to store versions of the `npm` packages installed in the current project.
 
-> `npm` (Node.js Package Manager) is a CLI tool which comes with Node.js installation and it's used for installing other tools like aftorementioned Bower, Gulp, etc...
+> `npm` (Node.js Package Manager) is a CLI tool which comes with Node.js installation and it's used for installing other tools like aforementioned Bower, Gulp, etc...
 
 Contents of my `package.json` file, shown below, is useful as we can see which Cordova plugins and dependencies are installed for the project, as well as some meta information like *name*, *version* and *description*:
 ```
@@ -308,7 +308,7 @@ So, [Git]((https://git-scm.com/)) on the other hand is (quoted from the official
 >a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.
 Git is easy to learn and has a tiny footprint with lightning fast performance. It outclasses SCM tools like Subversion, CVS, Perforce, and ClearCase with features like cheap local branching, convenient staging areas, and multiple workflows.
 
-Now that we got the basics out of the way, let's take a look at what the aftorementioned two files represent.
+Now that we got the basics out of the way, let's take a look at what the aforementioned two files represent.
 
 **.gitignore** is a configuration file for GitHub. Contents of the `.gitignore` file, shown below, basically instructs Git that it should not track folders **node_modules**, **platforms** and **plugins** when uploading the code to GitHub.
 ```
@@ -325,11 +325,11 @@ plugins/
 > If you're not using Git (and Github) in your workflow, I highly encourage you to do so, as it will prove really useful in the long run.
 
 ## <a name="refactoring"></a>Refactoring our application
-As said, we'll be spending most of our development time in the **www** folder and that's why we mentioned it just briefly in the previous section. We'll take a full deep dive in it here, by taking the two most imporant files (**index.html** and **app.js**) and explain their contents step by step.
+As said, we'll be spending most of our development time in the **www** folder and that's why we mentioned it just briefly in the previous section. We'll take a full deep dive in it here, by taking the two most important files (**index.html** and **app.js**) and explain their contents step by step.
 
 Also, we'll refactor our code into separate files, since Ionic Creator put everything in one. Finally, we'll add the calculator logic so that our calculator will work as expected.
 
-> Generally, putting all the code in one file and mixing logic and presentation (JavaScript and HTML code) is simply a big NO-NO, and often referred to as [spaghetti code](https://en.wikipedia.org/wiki/Spaghetti_code). You can learn more about refactoring your code from the cult book [Refactoring: Improving the Design of Existing Code](http://amzn.to/1LWo4Ow) by Martin Fowler, Kent Beck, and others. If you're searching for a bit lighter introduction to refactoring and good programing practices in general I can't recomment the classic [Code Complete 2](http://amzn.to/1LWomoq) by Steve McConnell enough.
+> Generally, putting all the code in one file and mixing logic and presentation (JavaScript and HTML code) is simply a big NO-NO, and often referred to as [spaghetti code](https://en.wikipedia.org/wiki/Spaghetti_code). You can learn more about refactoring your code from the cult book [Refactoring: Improving the Design of Existing Code](http://amzn.to/1LWo4Ow) by Martin Fowler, Kent Beck, and others. If you're searching for a bit lighter introduction to refactoring and good programming practices in general I can't recommend the classic [Code Complete 2](http://amzn.to/1LWomoq) by Steve McConnell enough.
 
 ### index.html file
 The starting point of our Ionic application is `index.html`, whose contents is as follows:
@@ -604,7 +604,7 @@ Just for reference, here's the contents of the `index.html` file, as it should l
 ```
 
 ### app.js file
-Contents of the **app.js** file bootstraps our Ionic (well, more acurately AngularJS) application, configures necessary plugings, and defines the states in our application. As we said before, the name of the root module matches the value given to the `ng-app` directive in the `index.html` file (**app** in our case). Also, we need to *inject* '`ionic`' module dependency to our root module so that we can use the Ionic library directives and other Ionic components.
+Contents of the **app.js** file bootstraps our Ionic (well, more accurately AngularJS) application, configures necessary plugins, and defines the states in our application. As we said before, the name of the root module matches the value given to the `ng-app` directive in the `index.html` file (**app** in our case). Also, we need to *inject* '`ionic`' module dependency to our root module so that we can use the Ionic library directives and other Ionic components.
 
 `$ionicPlatform.ready` event is triggered after the device (your mobile phone on which the application is started) is all set up and ready to use. This includes plugins which are used with this project. If you would try to check if some plugin is available outside the `ready` function callback, you could get wrong results due to the fact that it is possible that some plugin would not have been set up just yet. Using the aforementioned `$ionicPlatform.ready` event and placing your code to check for plugin instantiations solves these issues. You can learn more about ionicPlatform utility methods here: [http://ionicframework.com/docs/api/utility/ionic.Platform/](http://ionicframework.com/docs/api/utility/ionic.Platform/).
 
@@ -626,7 +626,7 @@ cordova-plugin-whitelist 1.0.0 "Whitelist"
 
 From the listing above we can see that there is no StatusBar plugin (org.apache.cordova.statusbar), so we can safely remove the corresponding lines in the `app.js` file.
 
-Inside the `config` function callback we're setting the routes for our application. Ionic uses [AngularUI Router](https://github.com/angular-ui/ui-router) which uses the concept of states. Since we moved our calculator UI into the `calculator.html` file inside the `templates` folder, we have to adjust the path to it accordingly. Also, we'll put our calculator logic inside the so called `CalculatorCtrl` controller. The state definition, with the acompanying controller definition should now look like this:
+Inside the `config` function callback we're setting the routes for our application. Ionic uses [AngularUI Router](https://github.com/angular-ui/ui-router) which uses the concept of states. Since we moved our calculator UI into the `calculator.html` file inside the `templates` folder, we have to adjust the path to it accordingly. Also, we'll put our calculator logic inside the so called `CalculatorCtrl` controller. The state definition, with the accompanying controller definition should now look like this:
 
 ```
 $stateProvider
@@ -736,14 +736,14 @@ Now you can run the application by executing the command
 
 and you should see your awesome calculator open up in your browser.
 
-As mentioned in the begining of this tutorial, you can take a look at the source code on [GitHub](https://github.com/Hitman666/Ionic_2ndTutorial), or you can take a look at the [live example](http://nikola-dev.com/IonicCalculator/mobile.html) of this application.
+As mentioned in the beginning of this tutorial, you can take a look at the source code on [GitHub](https://github.com/Hitman666/Ionic_2ndTutorial), or you can take a look at the [live example](http://nikola-dev.com/IonicCalculator/mobile.html) of this application.
 
 ## Conclusion
 In this tutorial we showed you how to create a calculator application step by step. We showed how to create a mockup of our idea, then we showed how to create an interface by using Ionic Creator, and finally how to refactor our application and create the logic with controllers.
 
 In the next tutorial we're going to take a look  at how to test your application on the real physical devices, and also how to use Ionic.io cloud service to share our application with other users without going through the app store. Also, we're going to take a look how to implement Google Analytics and Google Admob ads, and how to prepare our application for the stores. Also, we'll take a look at how to customize the icons and the application's splash screen.
 
-If you have any questions about this tutorial please read the following help guides. Of course, I encourage you to ask a question in the comments so that anyone else who may have a silmiar question or doubt, learns something too.
+If you have any questions about this tutorial please read the following help guides. Of course, I encourage you to ask a question in the comments so that anyone else who may have a similar question or doubt, learns something too.
 
 With this I leave you and hope you had a great learning experience with following this tutorial. See you in the next installment of this series!
 

--- a/how-to-polish-create-icons-and-splash-screen-images-add-ads-share-and-test-our-calculator-application/article.md
+++ b/how-to-polish-create-icons-and-splash-screen-images-add-ads-share-and-test-our-calculator-application/article.md
@@ -233,7 +233,7 @@ The icon is an important part of your application because it represents your app
 
 Ionic helps tremendously with this by providing a single Ionic CLI command to generate all the needed icon and splash screen sizes for us automatically. Also, Ionic created [Photoshop Icon Template](http://code.ionicframework.com/resources/icon.psd) and [Photoshop Splash Screen Template](http://code.ionicframework.com/resources/splash.psd), which you can download for free and use as a guideline for creating an icon.
 
-For when you're creating a branded product having a custom made icon is definitelly a must. However, in this case, we'll show how to use one of the free services to search for a free icon which we can use in our application (even if our application is a commercial application). I tend to use [IconFinder](https://www.iconfinder.com) a lot, and here are the setting which you have to use in order to filter out the calculator images which are Free (PRICE) and can be used in commercial applications and which do not even require a link back (LICENSE TYPE). *Of course, you can also choose to buy an image if you happen to find one that you like*. You can additionally search by format, size and background. The filters should look like this:
+For when you're creating a branded product having a custom made icon is definitely a must. However, in this case, we'll show how to use one of the free services to search for a free icon which we can use in our application (even if our application is a commercial application). I tend to use [IconFinder](https://www.iconfinder.com) a lot, and here are the setting which you have to use in order to filter out the calculator images which are Free (PRICE) and can be used in commercial applications and which do not even require a link back (LICENSE TYPE). *Of course, you can also choose to buy an image if you happen to find one that you like*. You can additionally search by format, size and background. The filters should look like this:
 
 ![](http://i.imgur.com/TDkaEbp.jpg)
 
@@ -806,7 +806,7 @@ However, if you want to build and deploy iOS applications to the App Store, you 
 
 There are some ways around this, like for example with using a so-called [Hackintosh](http://www.hackintosh.com/) computer, but honestly from my experience this is just not worth it.
 
-If you're really anti-Apple :), then you'll be happy to know that there are services which allow you to [rent a Mac in the cloud](http://www.macincloud.com/), just for the time you need to build your application. Also, Ionic promissed to build a service that will allow you to build mobile apps for any supported platform even if you don’t have a Mac, but we have to wait for this to become available.
+If you're really anti-Apple :), then you'll be happy to know that there are services which allow you to [rent a Mac in the cloud](http://www.macincloud.com/), just for the time you need to build your application. Also, Ionic promised to build a service that will allow you to build mobile apps for any supported platform even if you don’t have a Mac, but we have to wait for this to become available.
 
 > To **publish an app** in the App Store (or **test it on your own iOS device**) you'll need to purchase the *Apple Developer Program* license which costs **US $99 per year**. You’ll need to sign up at [http://developer.apple.com](http://developer.apple.com), but don't worry about this for now; we'll cover all the steps in our next tutorial where I'll guide you through the application deploy process for both the Apple's App Store and Google's Play Store.
 
@@ -840,13 +840,13 @@ If you exit the simulator back to the home screen (by pressing `COMMAND + SHIFT 
 
 ![](http://i.imgur.com/5KrFOmO.png)
 
-When we're testing our application in browser with `ionic serve` we have that great live realod feature. We can have that too in the emulator, if we run the emulator with the extra flag `–l`. If we also want to see the console.log output, as we would see it in the browser, then we have to add the flag `–c`:
+When we're testing our application in browser with `ionic serve` we have that great live reload feature. We can have that too in the emulator, if we run the emulator with the extra flag `–l`. If we also want to see the console.log output, as we would see it in the browser, then we have to add the flag `–c`:
 
 ```
 ionic emulate ios -lc
 ```
 
-> Since we need to have an Apple Developer account in order to run the application on our phsyical phone device, we will leave this for our next tutorial where we'll also show how to deploy the application to the actual App Store.
+> Since we need to have an Apple Developer account in order to run the application on our physical phone device, we will leave this for our next tutorial where we'll also show how to deploy the application to the actual App Store.
 
 ## Android settings
 There are no prerequisites for Android development regarding the operating systems; you can develop for Android on Mac, Linux, and Windows computers.
@@ -948,7 +948,7 @@ As mentioned in the [How to implement Google AdMob ads](#How to implement Google
 
 Android SDK has an emulator that can emulate the screen size and resolution of most Android devices, but to be honest it's way too slow and klunky and I recommend that you do not use it. Instead, download [Genymotion](https://www.genymotion.com/#!/) which is free for personal use.
 
-After you install and run Genymotion you will see an iterface like this:
+After you install and run Genymotion you will see an interface like this:
 
 ![](http://i.imgur.com/4Fh0rJb.jpg)
 

--- a/how-to-publish-our-calculator-application-to-the-apple-s-app-store-and-google-s-play-store/article.md
+++ b/how-to-publish-our-calculator-application-to-the-apple-s-app-store-and-google-s-play-store/article.md
@@ -179,21 +179,21 @@ The zipalign tool just takes the name of the signed file (we still have *unsigne
 
 `zipalign -v 4 SuperSimpleCalculator-release-unsigned.apk SuperSimpleCalculator.apk`
 
-The process finishes with the `Verification succesful` output and you will get a **SuperSimpleCalculator.apk** file which you can submit to the Google Play Store.
+The process finishes with the `Verification successful` output and you will get a **SuperSimpleCalculator.apk** file which you can submit to the Google Play Store.
 
 You may get an error like:
 
 > zipalign is not recognized as an internal or external command, operable program or batch file.
 
-In this case, you need to search your computer for the zipalign file, and make sure it's in your system PATH to fix this problem. Alternatively, you can enter a full path to the zipalign file (in my case, on Windows, the the path to the file was `C:\Android\android-sdk\build-tools\21.1.2\zipalign.exe`).
+In this case, you need to search your computer for the zipalign file, and make sure it's in your system PATH to fix this problem. Alternatively, you can enter a full path to the zipalign file (in my case, on Windows, the path to the file was `C:\Android\android-sdk\build-tools\21.1.2\zipalign.exe`).
 
 ### Building the update of your application
-To build an update of an existing app you have to follow the same steps except that you don't need to create another keystore. You have to use the **same keystore** to sign the application for every update, becase the update will be otherwise rejected and you'll have to create a new app listing.
+To build an update of an existing app you have to follow the same steps except that you don't need to create another keystore. You have to use the **same keystore** to sign the application for every update, because the update will be otherwise rejected and you'll have to create a new app listing.
 
 You must update the **version** in the **config.xml** file for the next release, otherwise the app will not be properly updated on your users' devices. To learn more about versioning you can take a look at the [official documentation](https://cordova.apache.org/docs/en/dev/config_ref/index.html), or this [StackOverflow question](http://stackoverflow.com/questions/25858547/phonegap-how-to-set-build-and-version-property-in-config-xml-for-ios).
 
 ### Creating the app listing and uploading the app to the Play Store
-The first thing you should do is sign up for the Google developer program at [https://play.google.com/apps/publish/signup/](https://play.google.com/apps/publish/signup/). If you're not going to make applications as an individial then it's recommended that you create a separate Google account for your apps (you need it to sign up). You'll need to pay **$25 one-time fee** for a developer license.
+The first thing you should do is sign up for the Google developer program at [https://play.google.com/apps/publish/signup/](https://play.google.com/apps/publish/signup/). If you're not going to make applications as an individual then it's recommended that you create a separate Google account for your apps (you need it to sign up). You'll need to pay **$25 one-time fee** for a developer license.
 
 You start by clicking the `Add new application` button on the right hand side as shown on the image below:
 
@@ -275,7 +275,7 @@ One the next screen, shown on the image below, select the plus (+) button in ord
 
 ![](http://i.imgur.com/BbK4KHq.png)
 
-On the next screen, shown partialy on the image below, you'll have to set the name of your app, and use the `Explicit App ID` option and set the `Bundle ID` to the value of the `id` in your Cordova `config.xml` <widget> tag.
+On the next screen, shown partially on the image below, you'll have to set the name of your app, and use the `Explicit App ID` option and set the `Bundle ID` to the value of the `id` in your Cordova `config.xml` <widget> tag.
 
 ![](http://i.imgur.com/fsENfcP.png)
 
@@ -288,7 +288,7 @@ Apple uses [iTunes Connect](https://itunesconnect.apple.com) to manage app submi
 
 ![](http://i.imgur.com/mvnrafK.png)
 
-Here you have to select the My Apps button, and on the next screen select the + button, just below the `iTunes Conenct My Apps` header, as shown on the image below:
+Here you have to select the My Apps button, and on the next screen select the + button, just below the `iTunes Connect My Apps` header, as shown on the image below:
 
 ![](http://i.imgur.com/68rK26r.png)
 
@@ -310,7 +310,7 @@ In the root directory of your application execute the following command:
 
 If everything went well you'll see the **BUILD SUCCEEDED** output in the console.
 
-### Oppening the project in Xcode
+### Opening the project in Xcode
 Now, open the `platforms/ios/SuperSimpleCalculator.xcodeproj` file in Xcode (of course you would change `SuperSimpleCalculator` with your own name).
 
 ![](http://i.imgur.com/3lSsexm.png)
@@ -321,7 +321,7 @@ Once the Xcode opens up the project, you should see the details about your app i
 
 You should just check that the bundle identifier is set up correctly, so that it's the same as the value you specified earlier in the app ID. Also, make sure that the version and build numbers are correct. Team option should be set to your Apple developer account. Under the deployment target you can choose which devices your application will support.
 
-Since we're on this setting screen right now, I should mention that it's **very important** that you select the **Requires full screen** option, otherwise you may (as I did) get the following error when uploading the app to the App Store (covered futher in the tutorial):
+Since we're on this setting screen right now, I should mention that it's **very important** that you select the **Requires full screen** option, otherwise you may (as I did) get the following error when uploading the app to the App Store (covered further in the tutorial):
 `Invalid Bundle. iPad Multitasking support requires these orientations: 'UIInterfaceOrientationPortrait,UIInterfaceOrientationPortraitUpsideDown,UIInterfaceOrientationLandscapeLeft,UIInterfaceOrientationLandscapeRight'. Found 'UIInterfaceOrientationPortrait,UIInterfaceOrientationPortraitUpsideDown' in bundle 'com.bitscoffee.PhotoMarks.iOS'.`
 
 You can learn more about this error from [this StackOverflow question](http://stackoverflow.com/questions/32559724/ipad-multitasking-support-requires-these-orientations).
@@ -400,7 +400,7 @@ After you submit your app for review you'll see the status of it in the My Apps 
 
 ![](http://i.imgur.com/Bm3LbQA.jpg)
 
-Apple prides itself with a manual review process, which basically means it can take several days for your app to be reviewed. You'll be notified of any issues or updates to your app status. From my personal experience it usualy takes up to 5 days for the app to be reviewed. 
+Apple prides itself with a manual review process, which basically means it can take several days for your app to be reviewed. You'll be notified of any issues or updates to your app status. From my personal experience it usually takes up to 5 days for the app to be reviewed. 
 
 ### Updating the app
 Since you'll probably want to update your app at some point you'll first have to update the build and version numbers in the Cordova `config.xml` file and then rebuild the application and open it up from the Xcode and follow the same steps all over again.

--- a/ionic-framework-a-definitive-10-000-word-guide/article.md
+++ b/ionic-framework-a-definitive-10-000-word-guide/article.md
@@ -47,7 +47,7 @@ A definite advantage of the mobile websites is that you can update them without 
 ### Hybrid app
 A hybrid app is a mobile application, written with the same languages that you use when building websites, with the addition that it contains an isolated browser instance, called **WebView**, which runs this web application inside of a native app. Hybrid apps can access the mobile device and use the additional phone features like for example camera or GPS.
 
-Definite advantage of the hybrid apps is that you can access the additional phone features via plugins and that you can do all the development with the same set of skills you use when developing _"normal"_ web applications. One of the disadvantages is that, even though it's improving, the so-called Web View has it's limitations in terms of speed. Basically, you wouldn't use a hybrid aproach if you wante to build a 3D game.
+Definite advantage of the hybrid apps is that you can access the additional phone features via plugins and that you can do all the development with the same set of skills you use when developing _"normal"_ web applications. One of the disadvantages is that, even though it's improving, the so-called Web View has it's limitations in terms of speed. Basically, you wouldn't use a hybrid approach if you want to build a 3D game.
 
 ##1. What is Ionic and why it's so good
 As I gave an [answer on StackOverflow](http://stackoverflow.com/questions/31179211/use-ionic-or-cordova/31180666):
@@ -173,7 +173,7 @@ Select the Input component and change its PLACEHOLDER to **0** (zero digit) and 
 
 Next, according to our mockup, we should add buttons that would represent the digits from **0** to **9**, and the buttons that would represent mathematical operations (+, -, *, /). Also, we will need the equals button (**=**) and a clear button (**C**).
 
-In the first row we need to have 4 buttons, the ones representing digits 7, 8, 9 and one representing a dividing operation. To acomplish this, we will use a **Button Bar** component from the Components panel so that we'll drag&drop it just below the Input field on the screen. You should see something like this now in your Ionic Creator window:
+In the first row we need to have 4 buttons, the ones representing digits 7, 8, 9 and one representing a dividing operation. To accomplish this, we will use a **Button Bar** component from the Components panel so that we'll drag&drop it just below the Input field on the screen. You should see something like this now in your Ionic Creator window:
 
 ![](http://i.imgur.com/CVcreWF.jpg)
 
@@ -266,7 +266,7 @@ Gulp is a JavaScript task runner that helps with rapid development by making use
 ### package.json
 **package.json** is a file used by `npm` to store versions of the `npm` packages installed in the current project.
 
-`npm` (Node.js Package Manager) is a CLI tool which comes with Node.js installation and it's used for installing other tools like aftorementioned Bower, Gulp, etc...
+`npm` (Node.js Package Manager) is a CLI tool which comes with Node.js installation and it's used for installing other tools like aforementioned Bower, Gulp, etc...
 
 ### .gitignore and README.md file
 Both .gitignore and README.md are files related to [GitHub](https://github.com/). I'm sure most of the readers know and use GitHub (and consequently [Git](https://git-scm.com/)).
@@ -285,10 +285,10 @@ We'll take a look at two most important files (**index.html** and **app.js**) an
 
 Also, we'll refactor our code into separate files, since Ionic Creator put everything in one. Finally, we'll add the calculator logic so that our calculator will work as expected.
 
-> Generally, putting all the code in one file and mixing logic and presentation (JavaScript and HTML code) is simply a big NO-NO, and often referred to as [spaghetti code](https://en.wikipedia.org/wiki/Spaghetti_code). You can learn more about refactoring your code from the cult book [Refactoring: Improving the Design of Existing Code](http://amzn.to/1LWo4Ow) by Martin Fowler, Kent Beck, and others. If you're searching for a bit lighter introduction to refactoring and good programing practices in general I can't recomment the classic [Code Complete 2](http://amzn.to/1LWomoq) by Steve McConnell enough.
+> Generally, putting all the code in one file and mixing logic and presentation (JavaScript and HTML code) is simply a big NO-NO, and often referred to as [spaghetti code](https://en.wikipedia.org/wiki/Spaghetti_code). You can learn more about refactoring your code from the cult book [Refactoring: Improving the Design of Existing Code](http://amzn.to/1LWo4Ow) by Martin Fowler, Kent Beck, and others. If you're searching for a bit lighter introduction to refactoring and good programming practices in general I can't recommend the classic [Code Complete 2](http://amzn.to/1LWomoq) by Steve McConnell enough.
 
 ### index.html file
-The starting point of our Ionic application is `index.html`. Now we'll go step by step throguh the this file by explaining the certain lines of code. Also, we'll remove the unnecessary pieces, and move some other parts of the code to different files.
+The starting point of our Ionic application is `index.html`. Now we'll go step by step through this file by explaining the certain lines of code. Also, we'll remove the unnecessary pieces, and move some other parts of the code to different files.
 
 The `<meta>` element is used to properly resize our application on mobile devices.
 
@@ -426,13 +426,13 @@ Just for reference, here's the contents of the `index.html` file, as it should l
 ```
 
 ### app.js file
-Contents of the **app.js** file bootstraps our Ionic (well, more acurately AngularJS) application, configures necessary plugings, and defines the states in our application. As we said before, the name of the root module matches the value given to the `ng-app` directive in the `index.html` file (**app** in our case). Also, we need to *inject* '`ionic`' module dependency to our root module so that we can use the Ionic library directives and other Ionic components.
+Contents of the **app.js** file bootstraps our Ionic (well, more accurately AngularJS) application, configures necessary plugins, and defines the states in our application. As we said before, the name of the root module matches the value given to the `ng-app` directive in the `index.html` file (**app** in our case). Also, we need to *inject* '`ionic`' module dependency to our root module so that we can use the Ionic library directives and other Ionic components.
 
 `$ionicPlatform.ready` event is triggered after the device (your mobile phone on which the application is started) is all set up and ready to use. This includes plugins which are used with this project. If you would try to check if some plugin is available outside the `ready` function callback, you could get wrong results due to the fact that it is possible that some plugin would not have been set up just yet. Using the aforementioned `$ionicPlatform.ready` event and placing your code to check for plugin instantiations solves these issues. You can learn more about ionicPlatform utility methods here: [http://ionicframework.com/docs/api/utility/ionic.Platform/](http://ionicframework.com/docs/api/utility/ionic.Platform/).
 
 Inside the `$ionicPlatform.ready` function's callback, we're detecting if a Keyboard plugin is available in our Ionic application. If so, we're hiding the keyboard accessory bar (buttons like `next`, `previous` and `done`). You can change these settings, and quite a bit of additional ones (see a [full list here](https://github.com/driftyco/ionic-plugin-keyboard)), as per your project's requirements.
 
-Inside the `config` function callback we're setting the routes for our application. Ionic uses [AngularUI Router](https://github.com/angular-ui/ui-router) which uses the concept of states. Since we moved our calculator UI into the `calculator.html` file inside the `templates` folder, we have to adjust the path to it accordingly. Also, we'll put our calculator logic inside the so called `CalculatorCtrl` controller. The state definition, with the acompanying controller definition should now look like this:
+Inside the `config` function callback we're setting the routes for our application. Ionic uses [AngularUI Router](https://github.com/angular-ui/ui-router) which uses the concept of states. Since we moved our calculator UI into the `calculator.html` file inside the `templates` folder, we have to adjust the path to it accordingly. Also, we'll put our calculator logic inside the so called `CalculatorCtrl` controller. The state definition, with the accompanying controller definition should now look like this:
 
 ```javascript
 $stateProvider
@@ -540,7 +540,7 @@ Now you can run the application by executing the command
 
 and you should see your awesome calculator open up in your browser.
 
-As mentioned in the begining of this section, you can take a look at the source code on [GitHub](https://github.com/Hitman666/Ionic_2ndTutorial), or you can take a look at the [live example](http://nikola-dev.com/IonicCalculator/mobile.html) of this application.
+As mentioned in the beginning of this section, you can take a look at the source code on [GitHub](https://github.com/Hitman666/Ionic_2ndTutorial), or you can take a look at the [live example](http://nikola-dev.com/IonicCalculator/mobile.html) of this application.
 
 ## Conclusion
 In this section we showed you how to create a calculator application step by step. We showed how to create a mockup of our idea, then we showed how to create an interface by using Ionic Creator, and finally how to refactor our application and create the logic with controllers.
@@ -734,7 +734,7 @@ The icon is an important part of your application because it represents your app
 
 Ionic helps tremendously by providing a single Ionic CLI command to generate all the needed icon and splash screen sizes for us automatically (which usually used to be a tedious work). Also, Ionic created [Photoshop Icon Template](http://code.ionicframework.com/resources/icon.psd) and [Photoshop Splash Screen Template](http://code.ionicframework.com/resources/splash.psd), which you can download for free and use as a guideline for creating an icon.
 
-When you're creating a branded product, having a custom made icon is definitelly a must. However, in this case, we'll show how to use one of the free services to search for a free icon which we can use in our application. I tend to use [IconFinder](https://www.iconfinder.com) a lot and these are the filters I used:
+When you're creating a branded product, having a custom made icon is definitely a must. However, in this case, we'll show how to use one of the free services to search for a free icon which we can use in our application. I tend to use [IconFinder](https://www.iconfinder.com) a lot and these are the filters I used:
 
 ![](http://i.imgur.com/TDkaEbp.jpg)
 
@@ -982,7 +982,7 @@ If you run the simulator with the extra `–l` flag you'll . If we also want to 
 ionic emulate ios -lc
 ```
 
-Since we need to have an Apple Developer account in order to run the application on our phsyical phone device, we will cover this in the next section where we'll also show how to deploy the application to the actual App Store.
+Since we need to have an Apple Developer account in order to run the application on our physical phone device, we will cover this in the next section where we'll also show how to deploy the application to the actual App Store.
 
 ### Android settings
 You can develop Android applications on Mac, Linux, and Windows computers. Android provides a number of tools for developers that are available for free from their [website](http://developer.android.com/).
@@ -1020,7 +1020,7 @@ The options that you need to check (and then click on `Install`) are:
 + Android SDK Build-tools (choose the newest one)
 + Android 6.0 (API 23) - here you can actually go with 5.1
 
-Android SDK has an emulator that can emulate the screen size and resolution of most Android devices, but to be honest it's way too slow and klunky and I recommend that you do not use it. Instead, download [Genymotion](https://www.genymotion.com/#!/) which is free for personal use.
+Android SDK has an emulator that can emulate the screen size and resolution of most Android devices, but to be honest it's way too slow and clunky and I recommend that you do not use it. Instead, download [Genymotion](https://www.genymotion.com/#!/) which is free for personal use.
 
 Since Ionic sees the Genymotion device as a real device attached to your computer, you can't run `ionic emulate android`, as we did in the iOS section. Instead, you need to use the Ionic's `run` command (before you do the build phase) like this:
 
@@ -1114,7 +1114,7 @@ To create a keystore, execute (change *SuperSimpleCalculator* keyword with your 
 
 `keytool -genkey -v -keystore SuperSimpleCalculator.keystore -alias SuperSimpleCalculator -keyalg RSA -keysize 2048 -validity 10000`
 
-You' wi'll be asked for a password two times (don't forget it!). The process looks like this:
+You will be asked for a password two times (don't forget it!). The process looks like this:
 
 This command will create a `SuperSimpleCalculator.keystore` file. You should place this file in a place where you'll remember it, because you'll need this file for any app updates you'll want to push to the Play Store. However, just to make things clear; **for every new application that you make, you need to create a new keystore file**.
 
@@ -1146,16 +1146,16 @@ The zipalign tool just takes the name of the signed file (we still have *unsigne
 
 `zipalign -v 4 SuperSimpleCalculator-release-unsigned.apk SuperSimpleCalculator.apk`
 
-The process finishes with the `Verification succesful` output and you will get a **SuperSimpleCalculator.apk** file which you can submit to the Google Play Store.
+The process finishes with the `Verification successful` output and you will get a **SuperSimpleCalculator.apk** file which you can submit to the Google Play Store.
 
 You may get an error like:
 
 > zipalign is not recognized as an internal or external command, operable program or batch file.
 
-In this case, you need to search your computer for the zipalign file, and make sure it's in your system PATH to fix this problem (in my case, on Windows, the the path to the file was `C:\Android\android-sdk\build-tools\21.1.2\zipalign.exe`).
+In this case, you need to search your computer for the zipalign file, and make sure it's in your system PATH to fix this problem (in my case, on Windows, the path to the file was `C:\Android\android-sdk\build-tools\21.1.2\zipalign.exe`).
 
 ### Building the update of your application
-To build an update of an existing app you have to follow the same steps, except that you have to use the **same keystore** to sign the application for every update, becase the update will be otherwise rejected and you'll have to create a new app listing.
+To build an update of an existing app you have to follow the same steps, except that you have to use the **same keystore** to sign the application for every update, because the update will be otherwise rejected and you'll have to create a new app listing.
 
 You must update the **version** in the **config.xml** file for the next release, otherwise the app will not be properly updated. To learn more about versioning you can take a look at the [official documentation](https://cordova.apache.org/docs/en/dev/config_ref/index.html), or this [StackOverflow question](http://stackoverflow.com/questions/25858547/phonegap-how-to-set-build-and-version-property-in-config-xml-for-ios).
 
@@ -1236,7 +1236,7 @@ One the next screen, shown on the image below, select the plus (+) button in ord
 
 ![](http://i.imgur.com/BbK4KHq.png)
 
-On the next screen, shown partialy on the image below, you'll have to set the name of your app, and use the `Explicit App ID` option and set the `Bundle ID` to the value of the `id` in your Cordova `config.xml` <widget> tag.
+On the next screen, shown partially on the image below, you'll have to set the name of your app, and use the `Explicit App ID` option and set the `Bundle ID` to the value of the `id` in your Cordova `config.xml` <widget> tag.
 
 ![](http://i.imgur.com/fsENfcP.png)
 
@@ -1249,7 +1249,7 @@ Apple uses [iTunes Connect](https://itunesconnect.apple.com) to manage app submi
 
 ![](http://i.imgur.com/mvnrafK.png)
 
-Here you have to select the My Apps button, and on the next screen select the + button, just below the `iTunes Conenct My Apps` header, as shown on the image below:
+Here you have to select the My Apps button, and on the next screen select the + button, just below the `iTunes Connect My Apps` header, as shown on the image below:
 
 ![](http://i.imgur.com/68rK26r.png)
 
@@ -1271,7 +1271,7 @@ In the root directory of your application execute the following command:
 
 If everything went well you'll see the **BUILD SUCCEEDED** output in the console.
 
-### Oppening the project in Xcode
+### Opening the project in Xcode
 Open the `platforms/ios/SuperSimpleCalculator.xcodeproj` file in Xcode (of course you would change `SuperSimpleCalculator` with your own name).
 
 ![](http://i.imgur.com/3lSsexm.png)
@@ -1282,7 +1282,7 @@ Once the Xcode opens up the project, you should see the details about your app i
 
 You should just check that the bundle identifier is set up correctly, so that it's the same as the value you specified earlier in the app ID. Also, make sure that the version and build numbers are correct. Team option should be set to your Apple developer account. Under the deployment target you can choose which devices your application will support.
 
-Since we're on this setting screen right now, I should mention that it's **very important** that you select the **Requires full screen** option, otherwise you may (as I did) get the following error when uploading the app to the App Store (covered futher in the tutorial):
+Since we're on this setting screen right now, I should mention that it's **very important** that you select the **Requires full screen** option, otherwise you may (as I did) get the following error when uploading the app to the App Store (covered further in the tutorial):
 
 ```
 Invalid Bundle. iPad Multitasking support requires these orientations: 'UIInterfaceOrientationPortrait,UIInterfaceOrientationPortraitUpsideDown,UIInterfaceOrientationLandscapeLeft,UIInterfaceOrientationLandscapeRight'. Found 'UIInterfaceOrientationPortrait,UIInterfaceOrientationPortraitUpsideDown' in bundle 'com.bitscoffee.PhotoMarks.iOS'.
@@ -1360,7 +1360,7 @@ After you submit your app for review you'll see the status of it in the My Apps 
 
 ![](http://i.imgur.com/Bm3LbQA.jpg)
 
-Apple prides itself with a manual review process, which basically means it can take several days for your app to be reviewed. You'll be notified of any issues or updates to your app status. From my personal experience it usualy takes up to 5 days for the app to be reviewed. 
+Apple prides itself with a manual review process, which basically means it can take several days for your app to be reviewed. You'll be notified of any issues or updates to your app status. From my personal experience it usually takes up to 5 days for the app to be reviewed. 
 
 ### Updating the app
 Since you'll probably want to update your app at some point you'll first have to update the build and version numbers in the Cordova `config.xml` file and then rebuild the application and open it up from the Xcode and follow the same steps all over again.

--- a/text-editors-for-beginners-15-ways-to-rule-the-world/article.md
+++ b/text-editors-for-beginners-15-ways-to-rule-the-world/article.md
@@ -190,7 +190,7 @@ Textastic can connect to cloud drives, ftp, and more. It’s extremely fast for 
 
 | **Name** | **Price** | **Operating System** | **Key Features** |
 |------------------|------------------------------|------------------|-------------------------------------------------|
-| Atom | Free / Open Source | WIN/MAC/LINUX | Packageas, Themes |
+| Atom | Free / Open Source | WIN/MAC/LINUX | Packages, Themes |
 | Brackets | Free / Open Source | WIN/MAC/LINUX | PSD Extract |
 | Sublime Text | Paid / `$70 USD` | WIN/MAC/LINUX | Power User, Commands |
 | Notepad++ | Free / Open Source | Windows | Easy |


### PR DESCRIPTION
Found a few typos (56 in total) while reading the tutorials. Thought that I should fix them so as to improve the overall quality of the articles.

Here is a list of changes I have done -

In `everything-you-need-to-know-about-json/article.md`
1. Remove misplaced a

In  `how-to-analyze-employee-data-using-sql/article.md`
1. Spelling mistake sytems → systems

In `how-to-create-a-calculator-application-with-ionic-framework-by-using-ionic-creator-for-ui/article.md`
1. Spelling mistake - acomplish → accomplish (2 instances)
2. Spelling mistake - Componenes → Components
3. Spelling mistake - ruller → ruler
4. Spelling mistake - remeber → remember
5. Spelling mistake - aftorementioned → aforementioned (2 instances)
6. Spelling mistake - imporant → important
7. Change programing to programming
8. Spelling mistake - recomment → recommend
9. Spelling mistake - acurately → accurately
10. Spelling mistake - plugings → plugins
11. Spelling mistake - acompanying → accompanying
12. Spelling mistake - begining → beginning
13. Spelling mistake - silmiar → similar

In `how-to-polish-create-icons-and-splash-screen-images-add-ads-share-and-test-our-calculator-application/article.md`
1. Spelling mistake - definitelly → definitely
2. Spelling mistake - promissed → promised
3. Spelling mistake - realod → reload
4. Spelling mistake - phsyical → physical
5. Spelling mistake - iterface → interface

In `how-to-publish-our-calculator-application-to-the-apple-s-app-store-and-google-s-play-store/article.md`
1. Spelling mistake - succesful → successful
2. Remove extra the
3. Spelling mistake becase → because
4. Spelling mistake - individial → individual
5. Spelling mistake - partialy → partially
6. Spelling mistake - Conenct → Connect
7. Spelling mistake - Oppening → Opening
8. Spelling mistake - futher → further
9. Spelling mistake - usualy → usually

In `ionic-framework-a-definitive-10-000-word-guide/article.md`
1. Spelling mistake - aproach → approach
2. Spelling mistake - wante → want
3. Spelling mistake - acomplish → accomplish
4. Spelling mistake - aftorementioned → aforementioned
5. Change programing to programming
6. Spelling mistake - recomment → recommend
7. Spelling mistake - throguh → through
8. Remove misplaced the
9. Spelling mistake - acurately → accurately
10. Spelling mistake - plugings → plugins
11. Spelling mistake - acompanying → accompanying
12. Spelling mistake - begining → beginning
13. Spelling mistake - definitelly → definitely
14. Spelling mistake - phsyical → physical
15. Spelling mistake - klunky → clunky
16. Remove misplaced '
17. Spelling mistake - wi'll → will
18. Spelling mistake - succesful → successful
19. Remove extra the
20. Spelling mistake - becase → because
21. Spelling mistake - partialy → partially
22. Spelling mistake - Conenct → Connect
23. Spelling mistake - Oppening → Opening
24. Spelling mistake - futher → further
25. Spelling mistake - usualy → usually

In `text-editors-for-beginners-15-ways-to-rule-the-world/article.md`
1. Spelling mistake - Packageas → Packages

In `faq.md`
1. Replace an with a
