### PR TITLE
updates react-vs-angular2-integration-with-rails guide

### DIFF
--- a/published/ruby-ruby-on-rails/react-vs-angular-2-integration-with-rails/article.md
+++ b/published/ruby-ruby-on-rails/react-vs-angular-2-integration-with-rails/article.md
@@ -15,6 +15,7 @@ rails new sampleapp
  
 ```ruby
 #Gemfile.rb
+gem 'rails'
 gem 'sqlite3'
 gem 'sprockets'
 gem 'rack-cors'


### PR DESCRIPTION
Adds rails gem to the list of required gems. The article makes it sound as if only 3 gems are needed and a reader may see that and accidentally paste over the rails gem, which is required to run the app.
