### PR TITLE
Updates to "Ruby on Rails Nested Attributes"

### DIFF
--- a/published/ruby-ruby-on-rails/ruby-on-rails-nested-attributes/article.md
+++ b/published/ruby-ruby-on-rails/ruby-on-rails-nested-attributes/article.md
@@ -189,9 +189,13 @@ id (`new_record`).
 ```javascript
 $('[data-form-prepend]').click( function(e) {
     var obj = $( $(this).attr('data-form-prepend') );
+    // Store `current_time` outside of the `each` loop, as a large number
+    //  of inputs can result in greater-than one second to update, which
+    //  will result in some of the inputs having a different form ID.
+    var current_time = (new Date()).getTime();
     obj.find('input, select, textarea').each( function() {
       $(this).attr( 'name', function() {
-        return $(this).attr('name').replace( 'new_record', (new Date()).getTime() );
+        return $(this).attr('name').replace( 'new_record', current_time );
       });
     });
     obj.insertBefore( this );


### PR DESCRIPTION
How unfortunate that this shows the entire page as a diff!

My change is *only* to the JavaScript loop to update `new_record` to the current timestamp. It should be done outside of the loop over the inputs, as having many inputs to iterate over will result in greater-than one second passing. If that timestamp is generated inside the loop, than some of the inputs will have different form IDs, which in turn results in unpredictable behavior from Rails (predictably broken, though). 