### PR TITLE
Re-order handleDelete and removeItemClient

### DIFF
--- a/published/ruby-ruby-on-rails/building-a-crud-interface-with-react-and-ruby-on-rails/article.md
+++ b/published/ruby-ruby-on-rails/building-a-crud-interface-with-react-and-ruby-on-rails/article.md
@@ -866,6 +866,14 @@ Everything works, but we’re encountering the same problem we had with adding a
 ```javascript
 // app/assets/javascripts/components/_body.js.jsx
 
+removeItemClient(id) {
+    var newItems = this.state.items.filter((item) => {
+        return item.id != id;
+    });
+
+    this.setState({ items: newItems });
+},
+
 handleDelete(id) {
     $.ajax({
         url: `/api/v1/items/${id}`,
@@ -875,15 +883,6 @@ handleDelete(id) {
         }
     });
 },
-
-removeItemClient(id) {
-    var newItems = this.state.items.filter((item) => {
-        return item.id != id;
-    });
-
-    this.setState({ items: newItems });
-},
-
 
 ```
 


### PR DESCRIPTION
It doesn't work in this order as the `handleDelete` doesn't know about `removeItemClient` because it's not declared yet.