### PR TITLE
Update deprecated StoreModel import

### DIFF
--- a/published/front-end-javascript/ui-state-management-with-redux-in-angular-4/article.md
+++ b/published/front-end-javascript/ui-state-management-with-redux-in-angular-4/article.md
@@ -95,6 +95,7 @@ Start off by adding the core dependencies for the Redux application store:
 ```
 $ yarn add @ngrx/core
 $ yarn add @ngrx/store
+$ yarn add --dev rxjs
 ```
 
 For asynchronous events such as pagination and loading bars, in the layout of the application, there needs to be a middleware:
@@ -239,7 +240,7 @@ import {metaReducer} from "./common/index";
   //...
   imports: [
     //Provide the application reducer to the store.
-    StoreModule.provideStore(metaReducer),
+    StoreModule.forRoot({ reducer: metaReducer }),
   ],
   //...
 })

--- a/published/front-end-javascript/ui-state-management-with-redux-in-angular-4/article.md
+++ b/published/front-end-javascript/ui-state-management-with-redux-in-angular-4/article.md
@@ -95,7 +95,6 @@ Start off by adding the core dependencies for the Redux application store:
 ```
 $ yarn add @ngrx/core
 $ yarn add @ngrx/store
-$ yarn add --dev rxjs
 ```
 
 For asynchronous events such as pagination and loading bars, in the layout of the application, there needs to be a middleware:


### PR DESCRIPTION
`StoreModel.provideStore` is deprecated in `@ngrx/store` version 4. We should now use `StoreModel.forRoot({ reducer: metaReducer })`

Example: 
https://github.com/ngrx/platform/blob/0fc1bcc2674eb0a755fcd64b576f244f25d7df41/example-app/app/app.module.ts