### PR TITLE
Updates to "Token-based authentication with Ruby on Rails 5 API"

### DIFF
--- a/published/ruby-ruby-on-rails/token-based-authentication-with-ruby-on-rails-5-api/article.md
+++ b/published/ruby-ruby-on-rails/token-based-authentication-with-ruby-on-rails-5-api/article.md
@@ -326,7 +326,7 @@ class ApplicationController < ActionController::API
   end
 end
 ```
-By using `before_action`, the server passes the request headers (using the built-in object property `request.headers`) to `AuthorizeApiRequest` every time the user makes a request. The request results are returned to the `@current_user`, thus becoming available to all controllers inheriting from `ApplicationController`.
+By using `before_action`, the server passes the request headers (using the built-in object property `request.headers`) to `AuthorizeApiRequest` every time the user makes a request. Calling `result` on `AuthorizeApiRequest.call(request.headers)` ic s coming from `SimpleCommand` module where it is defined as `attr_reader :result`. The request results are returned to the `@current_user`, thus becoming available to all controllers inheriting from `ApplicationController`.
 
 
 ### Does it work?


### PR DESCRIPTION
Explains where `result` on `AuthorizeApiRequest.call` call is coming from to make it a little bit clearer.